### PR TITLE
Exit Timestamps management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ yarn-error.log
 config.js
 keys.js
 .env
+package-lock.json
+ngrok
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -8,3 +8,6 @@ If you want to run the app without connecting your cellphone to the pc, you will
 2. Run both contact-tracing and Auth Server repos and expose each of them with the command: `./ngrok http 5005` replacing 5005 with the port you have your servers.
 3. Run `expo start`
 4. Download Expo to you mobile and scan the QR
+
+
+If you are having issues trying to run `./ngrok http <PORT>` for the second port, you can run `./ngrok start -config ngrok.yml --all` after checking the configuration file `ngrok.yml` contains the correct ports where the auth server and contact-tracing are listening.

--- a/ngrok.yml
+++ b/ngrok.yml
@@ -1,0 +1,8 @@
+authtoken: 1j74GCVOAMfr6a0Ch6kTtcsMtEO_3od9ZuHKp81grhgJNL22D
+tunnels:
+  first:
+    addr: 5000
+    proto: http
+  second:
+    addr: 5006
+    proto: http

--- a/ngrok.yml
+++ b/ngrok.yml
@@ -1,8 +1,8 @@
 authtoken: 1j74GCVOAMfr6a0Ch6kTtcsMtEO_3od9ZuHKp81grhgJNL22D
 tunnels:
   first:
-    addr: 5000
+    addr: 127.0.0.1:5000
     proto: http
   second:
-    addr: 5006
+    addr: 127.0.0.1:5006
     proto: http

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "main": "node_modules/expo/AppEntry.js",
   "scripts": {
     "start": "expo start",
+    "test": "./node_modules/.bin/env-cmd -f .env jest",
     "android": "expo start --android",
     "ios": "expo start --ios",
     "web": "expo start --web",
@@ -20,6 +21,7 @@
     "axios": "^0.21.0",
     "color": "^3.1.3",
     "deepmerge": "^4.2.2",
+    "env-cmd": "^10.1.0",
     "expo": "^39.0.0",
     "expo-analytics-segment": "~9.0.0",
     "expo-camera": "~9.0.0",
@@ -30,6 +32,8 @@
     "expo-status-bar": "~1.0.2",
     "firebase": "7.9.0",
     "grpc": "^1.24.3",
+    "jest": "^27.1.0",
+    "nock": "^13.1.3",
     "react": "16.13.1",
     "react-dom": "16.13.1",
     "react-native": "https://github.com/expo/react-native/archive/sdk-39.0.3.tar.gz",
@@ -67,5 +71,8 @@
     "eslint-plugin-react-hooks": "^1.3.0",
     "prettier": "^1.16.4"
   },
-  "private": true
+  "private": true,
+  "jest": {
+    "preset": "react-native"
+  }
 }

--- a/src/screens/QRScanScreen/index.js
+++ b/src/screens/QRScanScreen/index.js
@@ -43,7 +43,7 @@ function QRScanScreen({ navigation }) {
     try {
       setScanned(true);
       const parsedData = JSON.parse(data);
-      scan(parsedData.id, parsedData.isExit).catch(error =>
+      scan(parsedData.id, parsedData.isExit, parsedData.estimatedVisitDuration).catch(error =>
         openAlert('Error', error.response.data.reason)
       );
       openAlert(

--- a/src/services/CTUserAPIService.js
+++ b/src/services/CTUserAPIService.js
@@ -31,6 +31,11 @@ export const saveVisit = visitInfo => async genuxToken =>
     headers: { 'genux-token': genuxToken },
   });
 
+export const addExitTimestamp = visitInfo => async genuxToken =>
+  userApi.post('/visits/addExitTimestamp', visitInfo, {
+    headers: { 'genux-token': genuxToken },
+  });
+
 export const sendCodes = codes =>
   Promise.all(
     codes.map(code =>

--- a/src/services/LocalStorageService.js
+++ b/src/services/LocalStorageService.js
@@ -1,7 +1,6 @@
 import { AsyncStorage } from 'react-native';
 
 const SCAN_WINDOW = 14;
-const CLOSE_SCAN_WINDOW_SEARCH = 2;
 
 export const saveSession = session =>
   AsyncStorage.setItem('session', JSON.stringify(session));

--- a/src/services/LocalStorageService.js
+++ b/src/services/LocalStorageService.js
@@ -1,6 +1,7 @@
 import { AsyncStorage } from 'react-native';
 
 const SCAN_WINDOW = 14;
+const CLOSE_SCAN_WINDOW_SEARCH = 2;
 
 export const saveSession = session =>
   AsyncStorage.setItem('session', JSON.stringify(session));
@@ -25,12 +26,13 @@ export const getUserInfo = async () => {
 };
 
 export const saveScan = scan => {
-  const keyDate = scan.timestamp.toISOString().slice(0, 10);
+  const keyDate = scan.entranceTimestamp.toISOString().slice(0, 10);
   AsyncStorage.getItem(keyDate).then(scans => {
     const scansParsed = scans ? JSON.parse(scans) : [];
     scansParsed.push(scan);
     AsyncStorage.setItem(keyDate, JSON.stringify(scansParsed));
   });
+  AsyncStorage.setItem('ct-last-visit', JSON.stringify(scan));
 };
 
 export const getCodes = async () => {
@@ -48,4 +50,13 @@ export const getCodes = async () => {
   }
 
   return codes;
+};
+
+export const getLastVisit = async () => {
+  let lastVisit = await AsyncStorage.getItem('ct-last-visit');
+  return JSON.parse(lastVisit);
+};
+
+export const closePreviousVisit = async () => {
+  AsyncStorage.setItem('ct-last-visit', '');
 };

--- a/src/services/LocalStorageService.js
+++ b/src/services/LocalStorageService.js
@@ -57,6 +57,6 @@ export const getLastVisit = async () => {
   return JSON.parse(lastVisit);
 };
 
-export const closePreviousVisit = async () => {
+export const clearLastVisitInfo = async () => {
   AsyncStorage.setItem('ct-last-visit', '');
 };

--- a/src/services/ScanService.js
+++ b/src/services/ScanService.js
@@ -59,7 +59,7 @@ const scanExit = async (scanCode, estimatedVisitDuration) => {
   const exitTimestamp = new Date();
   const userInfo = await getUserInfo();
   const lastVisit = await getLastVisit();
-  const closingLastVisit = isExitScanClosingLastVisit(lastVisit, scanCode, estimatedVisitDuration);
+  const closingLastVisit = isExitScanClosingLastVisit(lastVisit, scanCode);
 
   // if the we have a last visit but the current exit QR is not closing it, we need to evaluate if we need to close the previous visit
   if (lastVisit && !closingLastVisit) {
@@ -116,17 +116,17 @@ const addExitTimestampToLastVisit = async (lastVisit) => {
 }
 
 // Check if the last visit is under the time window where it is still closable, and if it has the same scanCode as the exit QR code recently scanned
-const isExitScanClosingLastVisit = (lastVisit, scanCode, estimatedVisitDuration) => {
+export const isExitScanClosingLastVisit = (lastVisit, scanCode) => {
   if (!lastVisit || lastVisit.scanCode !== scanCode) {
     return false;
   }
   const minutesDifference = msToMinutes(new Date() - new Date(lastVisit.entranceTimestamp));
-  const maximumDifference = parseInt(estimatedVisitDuration) * EXIT_SCAN_VISIT_DURATION_WINDOW_MULTIPLIER;
+  const maximumDifference = parseInt(lastVisit.estimatedVisitDuration) * EXIT_SCAN_VISIT_DURATION_WINDOW_MULTIPLIER;
   return minutesDifference <= maximumDifference;
 }
 
 // Check if the last visit is under the time window where it is still closable
-const isLastVisitStillClosable = (lastVisit) => {
+export const isLastVisitStillClosable = (lastVisit) => {
   const minutesDifference = msToMinutes(new Date() - new Date(lastVisit.entranceTimestamp));
   const maximumDifference = parseInt(lastVisit.estimatedVisitDuration) * NEW_SCAN_CLOSING_LAST_VISIT_WINDOW_MULTIPLIER;
   return minutesDifference <= maximumDifference;

--- a/src/services/ScanService.js
+++ b/src/services/ScanService.js
@@ -1,7 +1,7 @@
 import 'react-native-get-random-values';
 import { v4 as uuidv4 } from 'uuid';
 import { withGenuxToken } from './CTAuthServerService';
-import { saveScan, getUserInfo, getLastVisit, closePreviousVisit } from './LocalStorageService';
+import { saveScan, getUserInfo, getLastVisit, clearLastVisitInfo } from './LocalStorageService';
 import { saveVisit, addExitTimestamp } from './CTUserAPIService';
 
 const EXIT_SCAN_VISIT_DURATION_WINDOW_MULTIPLIER = 3;
@@ -65,7 +65,7 @@ const scanExit = async (scanCode, estimatedVisitDuration) => {
   return withGenuxToken(addExitTimestamp(value))
     .then(res => {
       if (closingPreviousVisit) {
-        closePreviousVisit();
+        clearLastVisitInfo();
       } else {
         saveScan(value);
       }

--- a/src/services/ScanService.js
+++ b/src/services/ScanService.js
@@ -5,6 +5,7 @@ import { saveScan, getUserInfo, getLastVisit, clearLastVisitInfo } from './Local
 import { saveVisit, addExitTimestamp } from './CTUserAPIService';
 
 const EXIT_SCAN_VISIT_DURATION_WINDOW_MULTIPLIER = 3;
+const NEW_SCAN_CLOSING_LAST_VISIT_WINDOW_MULTIPLIER = 2;
 
 export const scan = async (scanCode, isExit, estimatedVisitDuration) => {
   if (!isExit) {
@@ -16,6 +17,11 @@ export const scan = async (scanCode, isExit, estimatedVisitDuration) => {
 const scanEntrance = async (scanCode, estimatedVisitDuration) => {
   const entranceTimestamp = new Date();
   const userInfo = await getUserInfo();
+  const lastVisit = await getLastVisit();
+  // if the we have a last visit we need to evaluate if we need to close it
+  if (lastVisit) {
+    await addExitTimestampToLastVisit(lastVisit);
+  }
   const value = {
     scanCode,
     entranceTimestamp,
@@ -34,7 +40,7 @@ const scanEntrance = async (scanCode, estimatedVisitDuration) => {
   };
   return withGenuxToken(saveVisit(value))
     .then(res => {
-      console.log(res);
+      value['estimatedVisitDuration'] = estimatedVisitDuration;
       saveScan(value);
       return res;
     })
@@ -46,6 +52,12 @@ const scanExit = async (scanCode, estimatedVisitDuration) => {
   const userInfo = await getUserInfo();
   const lastVisit = await getLastVisit();
   const closingPreviousVisit = isExitScanClosingPreviousVisit(lastVisit, scanCode, estimatedVisitDuration);
+
+  // if the we have a last visit but the current exit QR is not closing it, we need to evaluate if we need to close the previous visit
+  if (lastVisit && !closingPreviousVisit) {
+    await addExitTimestampToLastVisit(lastVisit);
+  }
+
   const value = {
     scanCode,
     exitTimestamp,
@@ -67,6 +79,7 @@ const scanExit = async (scanCode, estimatedVisitDuration) => {
       if (closingPreviousVisit) {
         clearLastVisitInfo();
       } else {
+        value['estimatedVisitDuration'] = estimatedVisitDuration;
         saveScan(value);
       }
       return res;
@@ -74,12 +87,37 @@ const scanExit = async (scanCode, estimatedVisitDuration) => {
     .catch(error => error.response);
 };
 
+const addExitTimestampToLastVisit = async (lastVisit) => {
+  if (!isPreviousVisitStillClosable(lastVisit)) {
+    clearLastVisitInfo();
+    return;
+  }
+  const exitTimestamp = new Date();
+  const value = {
+    scanCode: lastVisit.scanCode,
+    exitTimestamp,
+    userGeneratedCode: lastVisit.userGeneratedCode,
+  };
+  return withGenuxToken(addExitTimestamp(value))
+    .then(res => {
+      clearLastVisitInfo();
+      return res;
+    })
+    .catch(error => error.response);
+}
+
 const isExitScanClosingPreviousVisit = (lastVisit, scanCode, estimatedVisitDuration) => {
   if (!lastVisit || lastVisit.scanCode !== scanCode) {
     return false;
   }
   const minutesDifference = msToMinutes(new Date() - new Date(lastVisit.entranceTimestamp));
   const maximumDifference = parseInt(estimatedVisitDuration) * EXIT_SCAN_VISIT_DURATION_WINDOW_MULTIPLIER;
+  return minutesDifference <= maximumDifference;
+}
+
+const isPreviousVisitStillClosable = (lastVisit) => {
+  const minutesDifference = msToMinutes(new Date() - new Date(lastVisit.entranceTimestamp));
+  const maximumDifference = parseInt(lastVisit.estimatedVisitDuration) * NEW_SCAN_CLOSING_LAST_VISIT_WINDOW_MULTIPLIER;
   return minutesDifference <= maximumDifference;
 }
 

--- a/test/unit/closingLastVisit.test.js
+++ b/test/unit/closingLastVisit.test.js
@@ -10,10 +10,10 @@ describe('Testing the two isolated functions that determine if the last visit sh
 			const estimatedVisitDuration = 60
 			const lastVisit = {
 				entranceTimestamp,
-				"vaccinated": 0,
-				"covidRecovered": false,
-				"scanCode": "612bd2bdf9cd7d0019fb8a41",
-				"userGeneratedCode": "1982ec17-91a7-43e3-8152-7e70e899d5a2",
+				vaccinated: 0,
+				covidRecovered: false,
+				scanCode: "612bd2bdf9cd7d0019fb8a41",
+				userGeneratedCode: "1982ec17-91a7-43e3-8152-7e70e899d5a2",
 				estimatedVisitDuration
 			}
 
@@ -27,10 +27,10 @@ describe('Testing the two isolated functions that determine if the last visit sh
 			const estimatedVisitDuration = 30
 			const lastVisit = {
 				entranceTimestamp,
-				"vaccinated": 0,
-				"covidRecovered": false,
-				"scanCode": "612bd2bdf9cd7d0019fb8a41",
-				"userGeneratedCode": "1982ec17-91a7-43e3-8152-7e70e899d5a2",
+				vaccinated: 0,
+				covidRecovered: false,
+				scanCode: "612bd2bdf9cd7d0019fb8a41",
+				userGeneratedCode: "1982ec17-91a7-43e3-8152-7e70e899d5a2",
 				estimatedVisitDuration
 			}
 
@@ -44,10 +44,10 @@ describe('Testing the two isolated functions that determine if the last visit sh
 			const estimatedVisitDuration = 30
 			const lastVisit = {
 				entranceTimestamp,
-				"vaccinated": 0,
-				"covidRecovered": false,
-				"scanCode": "612bd2bdf9cd7d0019fb8a41",
-				"userGeneratedCode": "1982ec17-91a7-43e3-8152-7e70e899d5a2",
+				vaccinated: 0,
+				covidRecovered: false,
+				scanCode: "612bd2bdf9cd7d0019fb8a41",
+				userGeneratedCode: "1982ec17-91a7-43e3-8152-7e70e899d5a2",
 				estimatedVisitDuration
 			}
 
@@ -64,10 +64,10 @@ describe('Testing the two isolated functions that determine if the last visit sh
 			const scanCode = "612bd2bdf9cd7d0019fb8a41";
 			const lastVisit = {
 				entranceTimestamp,
-				"vaccinated": 0,
-				"covidRecovered": false,
+				vaccinated: 0,
+				covidRecovered: false,
 				scanCode,
-				"userGeneratedCode": "1982ec17-91a7-43e3-8152-7e70e899d5a2",
+				userGeneratedCode: "1982ec17-91a7-43e3-8152-7e70e899d5a2",
 				estimatedVisitDuration
 			}
 
@@ -83,10 +83,10 @@ describe('Testing the two isolated functions that determine if the last visit sh
 			const scanCodeCurrentScan = "612bd2bdf9cd7d0019fb8a42";
 			const lastVisit = {
 				entranceTimestamp,
-				"vaccinated": 0,
-				"covidRecovered": false,
-				"scanCode": scanCodeLastVisit,
-				"userGeneratedCode": "1982ec17-91a7-43e3-8152-7e70e899d5a2",
+				vaccinated: 0,
+				covidRecovered: false,
+				scanCode: scanCodeLastVisit,
+				userGeneratedCode: "1982ec17-91a7-43e3-8152-7e70e899d5a2",
 				estimatedVisitDuration
 			}
 
@@ -101,10 +101,10 @@ describe('Testing the two isolated functions that determine if the last visit sh
 			const scanCode = "612bd2bdf9cd7d0019fb8a41";
 			const lastVisit = {
 				entranceTimestamp,
-				"vaccinated": 0,
-				"covidRecovered": false,
+				vaccinated: 0,
+				covidRecovered: false,
 				scanCode,
-				"userGeneratedCode": "1982ec17-91a7-43e3-8152-7e70e899d5a2",
+				userGeneratedCode: "1982ec17-91a7-43e3-8152-7e70e899d5a2",
 				estimatedVisitDuration
 			}
 
@@ -119,10 +119,10 @@ describe('Testing the two isolated functions that determine if the last visit sh
 			const scanCode = "612bd2bdf9cd7d0019fb8a41";
 			const lastVisit = {
 				entranceTimestamp,
-				"vaccinated": 0,
-				"covidRecovered": false,
+				vaccinated: 0,
+				covidRecovered: false,
 				scanCode,
-				"userGeneratedCode": "1982ec17-91a7-43e3-8152-7e70e899d5a2",
+				userGeneratedCode: "1982ec17-91a7-43e3-8152-7e70e899d5a2",
 				estimatedVisitDuration
 			}
 

--- a/test/unit/closingLastVisit.test.js
+++ b/test/unit/closingLastVisit.test.js
@@ -1,0 +1,133 @@
+const scanService = require('../../src/services/ScanService');
+const nock = require('nock');
+
+describe('Testing the two isolated functions that determine if the last visit should be closed', () => {
+
+	describe('isLastVisitStillClosable() check if the last visit should be closed by a generic new visit', () => {
+		test('visit made one minute ago with an estimated visit duration of 60 minutes should be closable', () => {
+			const entranceTimestamp = new Date();
+			entranceTimestamp.setMinutes(entranceTimestamp.getMinutes() - 1);
+			const estimatedVisitDuration = 60
+			const lastVisit = {
+				entranceTimestamp,
+				"vaccinated": 0,
+				"covidRecovered": false,
+				"scanCode": "612bd2bdf9cd7d0019fb8a41",
+				"userGeneratedCode": "1982ec17-91a7-43e3-8152-7e70e899d5a2",
+				estimatedVisitDuration
+			}
+
+			const res = scanService.isLastVisitStillClosable(lastVisit);
+			expect(res).toBeTruthy();
+		});
+
+		test('visit made 31 minutes ago with an estimated visit duration of 30 minutes should be closable', () => {
+			const entranceTimestamp = new Date();
+			entranceTimestamp.setMinutes(entranceTimestamp.getMinutes() - 31);
+			const estimatedVisitDuration = 30
+			const lastVisit = {
+				entranceTimestamp,
+				"vaccinated": 0,
+				"covidRecovered": false,
+				"scanCode": "612bd2bdf9cd7d0019fb8a41",
+				"userGeneratedCode": "1982ec17-91a7-43e3-8152-7e70e899d5a2",
+				estimatedVisitDuration
+			}
+
+			const res = scanService.isLastVisitStillClosable(lastVisit);
+			expect(res).toBeTruthy();
+		});
+
+		test('visit made 90 minutes ago with an estimated visit duration of 30 minutes should not be closable', () => {
+			const entranceTimestamp = new Date();
+			entranceTimestamp.setMinutes(entranceTimestamp.getMinutes() - 90);
+			const estimatedVisitDuration = 30
+			const lastVisit = {
+				entranceTimestamp,
+				"vaccinated": 0,
+				"covidRecovered": false,
+				"scanCode": "612bd2bdf9cd7d0019fb8a41",
+				"userGeneratedCode": "1982ec17-91a7-43e3-8152-7e70e899d5a2",
+				estimatedVisitDuration
+			}
+
+			const res = scanService.isLastVisitStillClosable(lastVisit);
+			expect(res).toBeFalsy();
+		});
+	});
+
+	describe('isExitScanClosingLastVisit() check if the last visit should be closed by the current exit scan', () => {
+		test('visit made one minute ago with an estimated visit duration of 60 minutes, with the same scanId, should close last visit', () => {
+			const entranceTimestamp = new Date();
+			entranceTimestamp.setMinutes(entranceTimestamp.getMinutes() - 1);
+			const estimatedVisitDuration = 60;
+			const scanCode = "612bd2bdf9cd7d0019fb8a41";
+			const lastVisit = {
+				entranceTimestamp,
+				"vaccinated": 0,
+				"covidRecovered": false,
+				scanCode,
+				"userGeneratedCode": "1982ec17-91a7-43e3-8152-7e70e899d5a2",
+				estimatedVisitDuration
+			}
+
+			const res = scanService.isExitScanClosingLastVisit(lastVisit, scanCode);
+			expect(res).toBeTruthy();
+		});
+
+		test('visit made one minute ago with an estimated visit duration of 60 minutes, with the a different scanId, should not close last visit', () => {
+			const entranceTimestamp = new Date();
+			entranceTimestamp.setMinutes(entranceTimestamp.getMinutes() - 1);
+			const estimatedVisitDuration = 60;
+			const scanCodeLastVisit = "612bd2bdf9cd7d0019fb8a41";
+			const scanCodeCurrentScan = "612bd2bdf9cd7d0019fb8a42";
+			const lastVisit = {
+				entranceTimestamp,
+				"vaccinated": 0,
+				"covidRecovered": false,
+				"scanCode": scanCodeLastVisit,
+				"userGeneratedCode": "1982ec17-91a7-43e3-8152-7e70e899d5a2",
+				estimatedVisitDuration
+			}
+
+			const res = scanService.isExitScanClosingLastVisit(lastVisit, scanCodeCurrentScan);
+			expect(res).toBeFalsy();
+		});
+
+		test('visit made 29 minutes ago with an estimated visit duration of 10 minutes, with the same scanId, should close last visit', () => {
+			const entranceTimestamp = new Date();
+			entranceTimestamp.setMinutes(entranceTimestamp.getMinutes() - 29);
+			const estimatedVisitDuration = 10;
+			const scanCode = "612bd2bdf9cd7d0019fb8a41";
+			const lastVisit = {
+				entranceTimestamp,
+				"vaccinated": 0,
+				"covidRecovered": false,
+				scanCode,
+				"userGeneratedCode": "1982ec17-91a7-43e3-8152-7e70e899d5a2",
+				estimatedVisitDuration
+			}
+
+			const res = scanService.isExitScanClosingLastVisit(lastVisit, scanCode);
+			expect(res).toBeTruthy();
+		});
+
+		test('visit made 31 minutes ago with an estimated visit duration of 10 minutes, with the same scanId, should not close last visit', () => {
+			const entranceTimestamp = new Date();
+			entranceTimestamp.setMinutes(entranceTimestamp.getMinutes() - 31);
+			const estimatedVisitDuration = 10;
+			const scanCode = "612bd2bdf9cd7d0019fb8a41";
+			const lastVisit = {
+				entranceTimestamp,
+				"vaccinated": 0,
+				"covidRecovered": false,
+				scanCode,
+				"userGeneratedCode": "1982ec17-91a7-43e3-8152-7e70e899d5a2",
+				estimatedVisitDuration
+			}
+
+			const res = scanService.isExitScanClosingLastVisit(lastVisit, scanCode);
+			expect(res).toBeFalsy();
+		});
+	});
+});


### PR DESCRIPTION
Agrega la logica para cerrar visitas cuando se escanean nuevas entradas. 

En la [demo](https://drive.google.com/file/d/1LollhQY8OLavNoPbuSXrKRwvVeSUR1vT/view?usp=sharing) se muestran todos estos escenarios (se cortaron los primeros segundos de cada corte, pero basicamente decia algo como "en el escenario x la idea es...."):

1. Camino feliz, scan de entrada y salida del mismo lugar
2. Scan de entrada en lugar 1, scan de entrada en lugar 2, visita al lugar 1 se cierra
3. Scan de entrada en lugar 1, pasa el tiempo, scan de salida del lugar 1, se crean dos visitas, la primera sin exitTimestamp y la segunda con exitTimestamp
4. Scan de entrada en lugar 1, pasa el tiempo, scan de entrada del lugar 2, no se cierra la visita del primer lugar
5. Scan de entrada en lugar 1, scan de salida en lugar 2, se crean 2 visitas con exitTimestamp
6. Scan de salida sin escanear la entrada (asumimos que se olvido), crea una visita ya cerrada con entrada en base al estimatedVisitDuration

Si se les ocurren recomendaciones para refactorizar este codigo bienvenido, porque siento que quedo bastante choto